### PR TITLE
Feat/search functionality

### DIFF
--- a/app/controllers/api/v1/third_spaces_controller.rb
+++ b/app/controllers/api/v1/third_spaces_controller.rb
@@ -64,7 +64,79 @@ class Api::V1::ThirdSpacesController < ApplicationController
     end
   end
 
+  def search
+    find_matching_third_spaces(params)
+  end
+
   private
+  def find_matching_third_spaces(params)
+    search_results = []
+    Marker.all.each do |marker|
+      if (marker.tags.include?(params[:tags]) || !params[:tags]) &&
+          (marker.volume.include?(params[:volume]) || !params[:volume]) &&
+          (marker.gender_neutral_restrooms.include?(params[:gender_neutral_restrooms]) || !params[:gender_neutral_restrooms]) &&
+          (marker.accessible_entrance.include?(params[:accessible_entrance]) || !params[:accessible_entrance]) &&
+          (marker.customer_restrooms.include?(params[:customer_restrooms]) || !params[:customer_restrooms]) &&
+          (marker.parking.include?(params[:parking]) || !params[:parking]) &&
+          (marker.purchase_necessary.include?(params[:purchase_necessary]) || !params[:purchase_necessary]) &&
+          (marker.sober.include?(params[:sober]) || !params[:sober]) &&
+          (marker.child_friendly.include?(params[:child_friendly]) || !params[:child_friendly]) &&
+          (marker.light_level.include?(params[:light_level]) || !params[:light_level]) &&
+          (marker.public_transportation_nearby.include?(params[:public_transportation_nearby]) || !params[:public_transportation_nearby]) &&
+          (marker.bipoc_friendly.include?(params[:bipoc_friendly]) || !params[:bipoc_friendly]) &&
+          (marker.queer_friendly.include?(params[:queer_friendly]) || !params[:queer_friendly]) &&
+          (marker.staff_responsiveness.include?(params[:staff_responsiveness]) || !params[:staff_responsiveness])
+          search_results << marker 
+      end 
+    end
+    #   elsif params.include?(volume)
+
+    # end
+    # params.each do |key, value|
+    #   case key
+    #   when "tags"
+    #     # search_results = Marker.where(tags: ["#{value}"])
+    #     # search_results = Marker.where('tags.first ILIKE ?' "%#{value}")
+    #   else
+    #     search_results.each do |marker|
+    #       if !marker.(key).include?(value)
+    #         search_results.delete(marker)
+    #       end
+    #     end
+    #   end
+
+      #   # search_results = search_results.where(volume: ["#{value}"])
+      # elsif key == "accessible_entrance"
+      #   # search_results = search_results.where(accessible_entrance: ["#{value}"])
+      # elsif key == "customer_restrooms"
+      #   # search_results = search_results.where(customer_restrooms: ["#{value}"])
+      # elsif key == "parking"
+      #   # search_results = search_results.where(parking: ["#{value}"])
+      # elsif key == "purchase_necessary"
+      #   # search_results = search_results.where(purchase_necessary: ["#{value}"])
+      # elsif key == "sober"
+      #   # search_results = search_results.where(sober: ["#{value}"])
+      # elsif key == "child_friendly"
+      #   # search_results = search_results.where(child_friendly: ["#{value}"])
+      # elsif key == "light_level"
+      #   # search_results = search_results.where(light_level: ["#{value}"])
+      # elsif key == "public_transportation_nearby"
+      #   # search_results = search_results.where(public_transportation_nearby: ["#{value}"])
+      # elsif key == "bipoc_friendly"
+      #   # search_results = search_results.where(bipoc_friendly: ["#{value}"])
+      # elsif key == "queer_friendly"
+      #   # search_results = search_results.where(queer_friendly: ["#{value}"])
+      # elsif key == "staff_responsiveness"
+      #   # search_results = search_results.where(staff_responsiveness: ["#{value}"])
+      # end
+    # end
+    third_spaces = search_results.pluck(:third_space_id).map do |result|
+      ThirdSpace.find(result)
+    end
+
+    render json: ThirdSpaceSerializer.new(third_spaces), status: 200
+  end
+
   def update_all(marker, params)
     marker.update!(tags: ([marker[:tags]] + params[:tags]).flatten.reject(&:blank?))
     marker.update!(gender_neutral_restrooms: ([marker[:gender_neutral_restrooms]] + [params[:gender_neutral_restrooms]]).flatten.reject(&:blank?))

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,7 @@ Rails.application.routes.draw do
         collection do
           get :create_third_space
           delete :destroy_third_space
+          get :search
         end 
       end
 

--- a/spec/requests/api/v1/third_spaces/third_space_search_request_spec.rb
+++ b/spec/requests/api/v1/third_spaces/third_space_search_request_spec.rb
@@ -132,6 +132,51 @@ describe "Third Places SEARCH API Endpoint" do
     expect(space[:attributes][:markers][0][:tags]).to eq(@space_5_params[:tags])
     expect(space[:attributes][:markers][0][:volume]).to eq(@space_5_params[:volume])
     expect(space[:attributes][:markers][0][:accessible_entrance]).to eq(@space_5_params[:accessible_entrance])
+    
+    expect(space).to have_key(:id)
+
+    expect(space).to have_key(:type)
+    expect(space[:type]).to be_a(String)
+    expect(space[:type]).to eq("third_space")
+
+    expect(space).to have_key(:attributes)
+    expect(space[:attributes]).to be_an(Hash)
+
+    expect(space[:attributes]).to have_key(:yelp_id)
+    expect(space[:attributes][:yelp_id]).to be_a(String)
+
+    expect(space[:attributes]).to have_key(:name)
+    expect(space[:attributes][:name]).to be_a(String)
+
+    expect(space[:attributes]).to have_key(:address)
+    expect(space[:attributes][:address]).to be_a(String)
+
+    expect(space[:attributes]).to have_key(:rating)
+    expect(space[:attributes][:rating]).to be_a(Float)
+
+    expect(space[:attributes]).to have_key(:phone)
+    expect(space[:attributes][:phone]).to be_a(String)
+
+    expect(space[:attributes]).to have_key(:photos)
+    expect(space[:attributes][:photos]).to be_a(Array)
+
+    expect(space[:attributes]).to have_key(:lat)
+    expect(space[:attributes][:lat]).to be_a(Float)
+
+    expect(space[:attributes]).to have_key(:lon)
+    expect(space[:attributes][:lon]).to be_a(Float)
+
+    expect(space[:attributes]).to have_key(:price)
+    expect(space[:attributes][:price]).to be_a(String)
+
+    expect(space[:attributes]).to have_key(:hours)
+    expect(space[:attributes][:hours]).to be_a(String)
+
+    expect(space[:attributes]).to have_key(:category)
+    expect(space[:attributes][:category]).to be_a(String)
+
+    expect(space[:attributes]).to have_key(:open_now)
+    expect(space[:attributes][:open_now]).to be_a(TrueClass).or be_a(FalseClass)  
   end
 
   it "sends a list of third places when a place contains multiple tags" do
@@ -141,8 +186,68 @@ describe "Third Places SEARCH API Endpoint" do
     expect(response.status).to eq(200)
 
     third_spaces = JSON.parse(response.body, symbolize_names: true)[:data]
-    space = third_spaces.first
-    # binding.pry
+
     expect(third_spaces.count).to eq(4)
+
+    third_spaces.each do |space|
+      expect(space).to have_key(:id)
+
+      expect(space).to have_key(:type)
+      expect(space[:type]).to be_a(String)
+      expect(space[:type]).to eq("third_space")
+
+      expect(space).to have_key(:attributes)
+      expect(space[:attributes]).to be_an(Hash)
+
+      expect(space[:attributes]).to have_key(:yelp_id)
+      expect(space[:attributes][:yelp_id]).to be_a(String)
+
+      expect(space[:attributes]).to have_key(:name)
+      expect(space[:attributes][:name]).to be_a(String)
+
+      expect(space[:attributes]).to have_key(:address)
+      expect(space[:attributes][:address]).to be_a(String)
+
+      expect(space[:attributes]).to have_key(:rating)
+      expect(space[:attributes][:rating]).to be_a(Float)
+
+      expect(space[:attributes]).to have_key(:phone)
+      expect(space[:attributes][:phone]).to be_a(String)
+
+      expect(space[:attributes]).to have_key(:photos)
+      expect(space[:attributes][:photos]).to be_a(Array)
+
+      expect(space[:attributes]).to have_key(:lat)
+      expect(space[:attributes][:lat]).to be_a(Float)
+
+      expect(space[:attributes]).to have_key(:lon)
+      expect(space[:attributes][:lon]).to be_a(Float)
+
+      expect(space[:attributes]).to have_key(:price)
+      expect(space[:attributes][:price]).to be_a(String)
+
+      expect(space[:attributes]).to have_key(:hours)
+      expect(space[:attributes][:hours]).to be_a(String)
+
+      expect(space[:attributes]).to have_key(:category)
+      expect(space[:attributes][:category]).to be_a(String)
+
+      expect(space[:attributes]).to have_key(:open_now)
+      expect(space[:attributes][:open_now]).to be_a(TrueClass).or be_a(FalseClass)
+    end
+  end
+
+  it "sends a list of third places when a place contains multiple tags" do
+    search_params = ({public_transportation_nearby: "no",
+              bipoc_friendly: "yes"
+              })
+    get '/api/v1/third_spaces/search', params: search_params
+
+    expect(response).to be_successful
+    expect(response.status).to eq(200)
+
+    third_spaces = JSON.parse(response.body, symbolize_names: true)[:data]
+
+    expect(third_spaces.count).to eq(6)
   end
 end

--- a/spec/requests/api/v1/third_spaces/third_space_search_request_spec.rb
+++ b/spec/requests/api/v1/third_spaces/third_space_search_request_spec.rb
@@ -1,0 +1,148 @@
+require 'rails_helper'
+
+describe "Third Places SEARCH API Endpoint" do
+  before(:each) do
+    @space_1 = create(:third_space)
+    @space_2 = create(:third_space)
+    @space_3 = create(:third_space)
+    @space_4 = create(:third_space)
+    @space_5 = create(:third_space)
+    @space_6 = create(:third_space)
+
+    @space_1_params = ({
+      tags: ["happy"],
+      volume: ["quiet"], 
+      accessible_entrance: ["no"], 
+      customer_restrooms: ["no"], 
+      parking: ["yes"], 
+      purchase_necessary: ["yes"], 
+      sober: ["no"], 
+      child_friendly: ["yes"], 
+      light_level: ["low"], 
+      public_transportation_nearby: ["no"], 
+      bipoc_friendly: ["yes"], 
+      queer_friendly: ["yes"], 
+      staff_responsiveness: ["pushy"],
+      gender_neutral_restrooms: ["no"]
+    })
+
+    @space_2_params = ({
+      tags: ["studious"],
+      volume: ["loud"], 
+      accessible_entrance: ["no"], 
+      customer_restrooms: ["no"], 
+      parking: ["yes"], 
+      purchase_necessary: ["yes"], 
+      sober: ["no"], 
+      child_friendly: ["yes"], 
+      light_level: ["low"], 
+      public_transportation_nearby: ["no"], 
+      bipoc_friendly: ["yes"], 
+      queer_friendly: ["yes"], 
+      staff_responsiveness: ["pushy"],
+      gender_neutral_restrooms: ["no"]
+    })
+
+    @space_3_params = ({
+      tags: ["studious"],
+      volume: ["loud"], 
+      accessible_entrance: ["no"], 
+      customer_restrooms: ["no"], 
+      parking: ["yes"], 
+      purchase_necessary: ["yes"], 
+      sober: ["no"], 
+      child_friendly: ["yes"], 
+      light_level: ["low"], 
+      public_transportation_nearby: ["no"], 
+      bipoc_friendly: ["yes"], 
+      queer_friendly: ["yes"], 
+      staff_responsiveness: ["pushy"],
+      gender_neutral_restrooms: ["no"]
+    })
+
+    @space_4_params = ({
+      tags: ["studious"],
+      volume: ["quiet"], 
+      accessible_entrance: ["no"], 
+      customer_restrooms: ["no"], 
+      parking: ["yes"], 
+      purchase_necessary: ["yes"], 
+      sober: ["no"], 
+      child_friendly: ["yes"], 
+      light_level: ["low"], 
+      public_transportation_nearby: ["no"], 
+      bipoc_friendly: ["yes"], 
+      queer_friendly: ["yes"], 
+      staff_responsiveness: ["pushy"],
+      gender_neutral_restrooms: ["no"]
+    })
+
+    @space_5_params = ({
+      tags: ["happy"],
+      volume: ["loud"], 
+      accessible_entrance: ["no"], 
+      customer_restrooms: ["no"], 
+      parking: ["yes"], 
+      purchase_necessary: ["yes"], 
+      sober: ["no"], 
+      child_friendly: ["yes"], 
+      light_level: ["low"], 
+      public_transportation_nearby: ["no"], 
+      bipoc_friendly: ["yes"], 
+      queer_friendly: ["yes"], 
+      staff_responsiveness: ["pushy"],
+      gender_neutral_restrooms: ["no"]
+    })
+
+    @space_6_params = ({
+      tags: ["happy", "studious", "studious", "studious", "studious", "studious"],
+      volume: ["quiet"], 
+      accessible_entrance: ["no"], 
+      customer_restrooms: ["no"], 
+      parking: ["yes"], 
+      purchase_necessary: ["yes"], 
+      sober: ["no"], 
+      child_friendly: ["yes"], 
+      light_level: ["low"], 
+      public_transportation_nearby: ["no"], 
+      bipoc_friendly: ["yes"], 
+      queer_friendly: ["yes"], 
+      staff_responsiveness: ["pushy"],
+      gender_neutral_restrooms: ["no"]
+    })
+
+    patch "/api/v1/third_spaces/#{@space_1.id}", params: @space_1_params
+    patch "/api/v1/third_spaces/#{@space_2.id}", params: @space_2_params
+    patch "/api/v1/third_spaces/#{@space_3.id}", params: @space_3_params
+    patch "/api/v1/third_spaces/#{@space_4.id}", params: @space_4_params
+    patch "/api/v1/third_spaces/#{@space_5.id}", params: @space_5_params
+    patch "/api/v1/third_spaces/#{@space_6.id}", params: @space_6_params
+  end
+
+  it "sends a list of third places matching criteria" do
+    get '/api/v1/third_spaces/search?tags=happy&volume=loud'
+
+    expect(response).to be_successful
+    expect(response.status).to eq(200)
+
+    third_spaces = JSON.parse(response.body, symbolize_names: true)[:data]
+    space = third_spaces.first
+    # binding.pry
+    expect(third_spaces.count).to eq(1)
+    expect(space[:attributes][:markers][0][:tags]).to eq(@space_5_params[:tags])
+    expect(space[:attributes][:markers][0][:volume]).to eq(@space_5_params[:volume])
+    expect(space[:attributes][:markers][0][:accessible_entrance]).to eq(@space_5_params[:accessible_entrance])
+  end
+
+  it "sends a list of third places when a place contains multiple tags" do
+    get '/api/v1/third_spaces/search?tags=studious'
+
+    expect(response).to be_successful
+    expect(response.status).to eq(200)
+
+    third_spaces = JSON.parse(response.body, symbolize_names: true)[:data]
+    space = third_spaces.first
+    # binding.pry
+    expect(third_spaces.count).to eq(4)
+  end
+end


### PR DESCRIPTION
#### Keypoints (What Changes Have Been Made):
- Adds search functionality for third spaces
- BE will take in a request from FE in format of     
```
    get '/api/v1/third_spaces/search', params: ({public_transportation_nearby: "no",
              bipoc_friendly: "yes"
              })
```
- and send back a response to FE in the form of a json index response
#### Errors/Troubleshooting Notes (As Needed):
(Please include specific lines/files affected if needed)

#### Necessary Checkmarks:
    [x] All Tests are Passing
    [x] Modifications Made on Tests
    [] Broke Code
    
#### Reasoning for Selection:

#### Notes for Team:
There is a lot of leftover commented-out code here; I figured I'd leave it in for now until we have the big picture and we can either integrate it or delete it a few days from now. I'd like to refactor the search functionality before we're done.